### PR TITLE
Bugfix/#11 preview not working with invalid json

### DIFF
--- a/controller/ResponseController.js
+++ b/controller/ResponseController.js
@@ -57,9 +57,10 @@ ResponseController.prototype = extend(ResponseController.prototype, {
 
 		try {
 			data = JSON.parse(data);
+			data = JSON.stringify(data, null, 2);
 		} catch (err) {}
 
-		res.send(JSON.stringify(data, null, 2));
+		res.send(data);
 		res.end();
 	},
 


### PR DESCRIPTION
As per bug #11 Preview is one line since JSON is not valid

`"componentId": <%params.id%>`

If JSON is not valid it should not be stringified.