### PR TITLE
fix swagger import issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+NPM_TOKEN ?= '000-0000000000'
+CI_BUILD_NUMBER ?= 2 
+VERSION ?= 0.0.$(CI_BUILD_NUMBER)
+
+package:
+	# https://docs.npmjs.com/cli/install
+	@npm install --only=production --slient
+
+test: package
+	# https://docs.npmjs.com/cli/install
+	@npm install --only=dev --slient
+	# https://docs.npmjs.com/cli/test
+	@npm test
+
+publish: test
+	@echo "//registry.npmjs.org/:_authToken=$(NPM_TOKEN)" > ~/.npmrc
+	@echo "publishing $(VERSION)"
+	# https://docs.npmjs.com/cli/version
+	@npm version --no-git-tag-version $(VERSION)
+	# https://docs.npmjs.com/cli/publish
+	@npm publish
+
+version:
+	@echo $(VERSION)

--- a/controller/MockController.js
+++ b/controller/MockController.js
@@ -62,6 +62,12 @@ MockController.prototype = extend(MockController.prototype, {
 			return true;
 		}
 
+        if (path == this.options.swaggerImport.path) {
+            var fc=this.readFile(path.substring(1));
+            res.send(fc);
+            return true;
+        }
+
 		if (preferences && preferences.responseDelay) {
 			timeout = parseInt(preferences.responseDelay);
 		}

--- a/package.json
+++ b/package.json
@@ -1,51 +1,51 @@
 {
-	"name": "node-mock-server",
-	"version": "0.11.0",
-	"description": "File based Node API mock server",
-	"email": "simon.mollweide@web.de",
-	"author": "Simon Mollweide <simon.mollweide@web.de>",
-	"url": "https://github.com/smollweide/node-mock-server",
-	"repository": {
-		"type": "github",
-		"url": "https://github.com/smollweide/node-mock-server"
-	},
-	"bugs": {
-		"url": "https://github.com/smollweide/node-mock-server/issues"
-	},
-	"scripts": {
-		"start": "node app.js",
-		"test": "mocha test/tests.js"
-	},
-	"main": "mock-server.js",
-	"keywords": [
-		"node",
-		"npm",
-		"mock",
-		"rest",
-		"rest API",
-		"json",
-		"DTO",
-		"Swagger"
-	],
-	"engines": {
-		"node": ">=0.12.7"
-	},
-	"preferGlobal": false,
-	"private": false,
-	"license": "MIT",
-	"dependencies": {
-		"body-parser": "^1.15.0",
-		"chip": "0.0.5",
-		"deasync": "^0.1.4",
-		"ejs": "^2.4.1",
-		"express": "^4.13.4",
-		"extend": "^3.0.0",
-		"faker": "^4.1.0",
-		"request": "^2.72.0"
-	},
-	"devDependencies": {
-		"babel-eslint": "^6.0.3",
-		"eslint": "^2.8.0",
-		"mocha": "^2.4.5"
-	}
+  "name": "blt-node-mock-server",
+  "version": "0.0.2",
+  "description": "File based Node API mock server",
+  "email": "simon.mollweide@web.de",
+  "author": "Simon Mollweide <simon.mollweide@web.de> yaofei",
+  "url": "https://github.com/meetup/node-mock-server",
+  "repository": {
+    "type": "github",
+    "url": "https://github.com/meetup/node-mock-server"
+  },
+  "bugs": {
+    "url": "https://github.com/smollweide/node-mock-server/issues"
+  },
+  "scripts": {
+    "start": "node app.js",
+    "test": "mocha test/tests.js"
+  },
+  "main": "mock-server.js",
+  "keywords": [
+    "node",
+    "npm",
+    "mock",
+    "rest",
+    "rest API",
+    "json",
+    "DTO",
+    "Swagger"
+  ],
+  "engines": {
+    "node": ">=0.12.7"
+  },
+  "preferGlobal": false,
+  "private": false,
+  "license": "MIT",
+  "dependencies": {
+    "body-parser": "^1.15.0",
+    "chip": "0.0.5",
+    "deasync": "^0.1.4",
+    "ejs": "^2.4.1",
+    "express": "^4.13.4",
+    "extend": "^3.0.0",
+    "faker": "^4.1.0",
+    "request": "^2.72.0"
+  },
+  "devDependencies": {
+    "babel-eslint": "^6.0.3",
+    "eslint": "^2.8.0",
+    "mocha": "^2.4.5"
+  }
 }


### PR DESCRIPTION
Hi smollweide,

when I am using your 'node-mock-server' directly from npm install and `require('node-mock-server')` in app.js. The swagger import is not working. The server tried to assume the swagger definition path is a mocked endpoint, then the server crash.
![screen shot 2017-04-05 at 11 22 40 am](https://cloud.githubusercontent.com/assets/1409120/24713053/89f0bfda-19f2-11e7-82da-dfec670c0b37.png)


