### PR TITLE
Matched documentation files to actual default port

### DIFF
--- a/doc/readme-ui-documentation.md
+++ b/doc/readme-ui-documentation.md
@@ -1,6 +1,6 @@
 # Using the node-mock-server UI
 
-The mock server UI is available at _http://localhost:3003_ (or at the port you have defined via options).
+The mock server UI is available at _http://localhost:3001_ (or at the port you have defined via options).
 
 If the service you want to mock provides a Swagger definition and you have provided a [`swaggerImport` configuration item](https://github.com/smollweide/node-mock-server/blob/c52adcf2a80999dd6876062006cf72c1ef124a78/demo/index.js#L41-L53), you may perform a Swagger import via the small triangle button in the top right of the UI page.
  

--- a/doc/readme-usage-examples.md
+++ b/doc/readme-usage-examples.md
@@ -18,9 +18,9 @@ mockServer({
   dirName: __dirname,
   title: 'Api mock server',
   version: 2,
-  urlBase: 'http://localhost:3003',
+  urlBase: 'http://localhost:3001',
   urlPath: '/rest/v2',
-  port: 3003,
+  port: 3001,
   uiPath: '/',
   funcPath: path.join(__dirname, '/func'),
   headers: {


### PR DESCRIPTION
I noticed the documentation files didn't match where it was truly running, but then realized the console directed me to the correct port. Fairly trivial, but might save folks a few minutes.