### PR TITLE
[fix] do not proxy transfer encoding header

### DIFF
--- a/lib/controller/MockController.js
+++ b/lib/controller/MockController.js
@@ -119,8 +119,11 @@ MockController.prototype = extend(MockController.prototype, {
 			headers: req.headers,
 			success: function (data, response) {
 				var statusCode = parseInt(response.statusCode, 10);
+				var headersToSkip = ['transfer-encoding'];
 				this.forIn(response.headers, function (key, value) {
-					res.setHeader(key, value);
+					if (! headersToSkip.includes(key)) {
+						res.setHeader(key, value);
+					}
 				});
 				res.statusCode = response.statusCode;
 				res.send(data);


### PR DESCRIPTION
- The express server sets transfer encoding / content length itself on send()
- This may conflict with what the proxy (tunnel) originally returned.