### PR TITLE
Allow usage of functions as the options.accessControlAllow* headers

### DIFF
--- a/doc/readme-options.md
+++ b/doc/readme-options.md
@@ -79,29 +79,33 @@ A string that define the header "Content-Type".
 
 
 #### options.accessControlExposeHeaders
-Type: `String`
+Type: `String` or `function`
 Default value: `X-Total-Count`
 
-A string that define the header "Access-Control-Expose-Headers".
+A string that define the header "Access-Control-Expose-Headers". If a function
+is used, it will be called with the request object as the only parameter. 
 
 #### options.accessControlAllowOrigin
-Type: `String`
+Type: `String` or `function`
 Default value: `*`
 
-A string that define the header "Access-Control-Allow-Origin".
+A string that define the header "Access-Control-Allow-Origin". If a function
+is used, it will be called with the request object as the only parameter.
 
 #### options.accessControlAllowMethods
-Type: `String`
+Type: `String` or `function`
 Default value: `GET, POST, PUT, OPTIONS, DELETE, PATCH, HEAD`
 
-A string that define the header "Access-Control-Allow-Methods".
+A string that define the header "Access-Control-Allow-Methods". If a function
+is used, it will be called with the request object as the only parameter.
 
 
 #### options.accessControlAllowHeaders
-Type: `String`
+Type: `String` or `function`
 Default value: `origin, x-requested-with, content-type`
 
-A string that define the header "Access-Control-Allow-Headers".
+A string that define the header "Access-Control-Allow-Headers". If a function
+is used, it will be called with the request object as the only parameter.
 
 #### options.middleware
 Type: `Object`

--- a/lib/controller/MockController.js
+++ b/lib/controller/MockController.js
@@ -775,10 +775,26 @@ MockController.prototype = extend(MockController.prototype, {
 			res.setHeader(key, value);
 		});
 		res.setHeader('Content-Type', this.options.contentType);
-		res.setHeader('Access-Control-Expose-Headers', this.options.accessControlExposeHeaders);
-		res.setHeader('Access-Control-Allow-Origin', this.options.accessControlAllowOrigin);
-		res.setHeader('Access-Control-Allow-Methods', this.options.accessControlAllowMethods);
-		res.setHeader('Access-Control-Allow-Headers', this.options.accessControlAllowHeaders);
+		res.setHeader('Access-Control-Expose-Headers',
+			typeof this.options.accessControlExposeHeaders === 'function' ?
+				this.options.accessControlExposeHeaders(res.req) :
+				this.options.accessControlExposeHeaders
+		);
+		res.setHeader('Access-Control-Allow-Origin',
+			typeof this.options.accessControlAllowOrigin === 'function' ?
+				this.options.accessControlAllowOrigin(res.req) :
+				this.options.accessControlAllowOrigin
+		);
+		res.setHeader('Access-Control-Allow-Methods',
+			typeof this.options.accessControlAllowMethods === 'function' ?
+				this.options.accessControlAllowMethods(res.req) :
+				this.options.accessControlAllowMethods
+		);
+		res.setHeader('Access-Control-Allow-Headers',
+			typeof this.options.accessControlAllowHeaders === 'function' ?
+				this.options.accessControlAllowHeaders(res.req) :
+				this.options.accessControlAllowHeaders
+		);
 	},
 
 });


### PR DESCRIPTION
Our project requires us to use `credentials: include` in some cases, and as `node-mock-server` uses strings for the `Access-Control-Allow` this is a bit problematic.

When using `credentials: include` you need `Access-Control-Allow-Origin` to return a list of allowed domains, `*` is not a correct value.

This PR adds the option to have `options.accessControlAllowOrigin` (and other headers of the CORS mechanism) be either a string or a function. If it's a function, it will be called with the original request object allowing you for example to specify:

```
options.accessControlAllowOrigin: (req) => req.headers.referer
```

which will return the proper string.