### PR TITLE
Add the missing Access-Control-Allow-Credentials header

### DIFF
--- a/demo/tunnel.js
+++ b/demo/tunnel.js
@@ -35,6 +35,7 @@ function setHeaders(res) {
 	res.setHeader('Access-Control-Allow-Origin', options.accessControlAllowOrigin);
 	res.setHeader('Access-Control-Allow-Methods', options.accessControlAllowMethods);
 	res.setHeader('Access-Control-Allow-Headers', options.accessControlAllowHeaders);
+	res.setHeader('Access-Control-Allow-Credentials', options.accessControlAllowCredentials);	
 }
 
 app.get('/rest/v1/products', (req, res) => {

--- a/doc/readme-options.md
+++ b/doc/readme-options.md
@@ -99,12 +99,18 @@ Default value: `GET, POST, PUT, OPTIONS, DELETE, PATCH, HEAD`
 A string that define the header "Access-Control-Allow-Methods". If a function
 is used, it will be called with the request object as the only parameter.
 
-
 #### options.accessControlAllowHeaders
 Type: `String` or `function`
 Default value: `origin, x-requested-with, content-type`
 
 A string that define the header "Access-Control-Allow-Headers". If a function
+is used, it will be called with the request object as the only parameter.
+
+#### options.accessControlAllowCredentials
+Type: `String` or `function`
+Default value: `true`
+
+A string that define the header "Access-Control-Allow-Credentials". If a function
 is used, it will be called with the request object as the only parameter.
 
 #### options.middleware

--- a/lib/cli/ask/headers.js
+++ b/lib/cli/ask/headers.js
@@ -60,6 +60,7 @@ function askForHeaders() {
 					accessControlAllowOrigin: defaultOptions.accessControlAllowOrigin,
 					accessControlAllowMethods: defaultOptions.accessControlAllowMethods,
 					accessControlAllowHeaders: defaultOptions.accessControlAllowHeaders,
+					accessControlAllowCredentials: defaultOptions.accessControlAllowCredentials,
 				});
 				return;
 			}
@@ -93,6 +94,12 @@ function askForHeaders() {
 					name: 'accessControlAllowHeaders',
 					message: 'Enter "Access-Control-Allow-Headers" response header',
 					default: 'origin, x-requested-with, content-type',
+				},
+				{
+					type: 'input',
+					name: 'accessControlAllowCredentials',
+					message: 'Enter "Access-Control-Allow-Credentials" response header',
+					default: 'true',
 				},
 			]).then(function (answersOtherHeaders) {
 				askForAddHeader({}, function (answerHeaders) {

--- a/lib/controller/MockController.js
+++ b/lib/controller/MockController.js
@@ -795,6 +795,11 @@ MockController.prototype = extend(MockController.prototype, {
 				this.options.accessControlAllowHeaders(res.req) :
 				this.options.accessControlAllowHeaders
 		);
+		res.setHeader('Access-Control-Allow-Credentials',
+		typeof this.options.accessControlAllowCredentials === 'function' ?
+			this.options.accessControlAllowCredentials(res.req) :
+			this.options.accessControlAllowCredentials
+	);
 	},
 
 });

--- a/lib/controller/MockController.js
+++ b/lib/controller/MockController.js
@@ -796,10 +796,10 @@ MockController.prototype = extend(MockController.prototype, {
 				this.options.accessControlAllowHeaders
 		);
 		res.setHeader('Access-Control-Allow-Credentials',
-		typeof this.options.accessControlAllowCredentials === 'function' ?
-			this.options.accessControlAllowCredentials(res.req) :
-			this.options.accessControlAllowCredentials
-	);
+			typeof this.options.accessControlAllowCredentials === 'function' ?
+				this.options.accessControlAllowCredentials(res.req) :
+				this.options.accessControlAllowCredentials
+		);
 	},
 
 });

--- a/lib/defaults/options-defaults.js
+++ b/lib/defaults/options-defaults.js
@@ -12,6 +12,7 @@ module.exports = {
 	accessControlAllowOrigin: '*',
 	accessControlAllowMethods: 'GET, POST, PUT, OPTIONS, DELETE, PATCH, HEAD',
 	accessControlAllowHeaders: 'origin, x-requested-with, content-type',
+	accessControlAllowCredentials: 'true',
 	headers: {},
 	open: true,
 };


### PR DESCRIPTION
Looks like my last PR ( https://github.com/smollweide/node-mock-server/pull/89 ) wasn't enough, need to also add the Credentials header.