### PR TITLE
Allow to specify HTTP response code for success responses

### DIFF
--- a/lib/controller/MockController.js
+++ b/lib/controller/MockController.js
@@ -287,6 +287,11 @@ MockController.prototype = extend(MockController.prototype, {
 			}
 
 			if (outStr) {
+				var status = this._getHttpStatusFromFileName(options.responseFilePath);
+				if (status && options.res.statusCode === 200) {
+					options.res.statusCode = status;
+				}
+
 				options.res.send(outStr);
 			} else {
 				options.res.send(responseFile);
@@ -397,14 +402,7 @@ MockController.prototype = extend(MockController.prototype, {
 	 * @private
 	 */
 	_sendError: function (options) {
-		var status;
-		var reg = (/(error)(-)([0-9]{3})/).exec(options.expectedResponse.name);
-
-		if (reg === null) {
-			status = 500;
-		} else {
-			status = parseInt(reg[3], 10);
-		}
+		var status = this._getHttpStatusFromFileName(options.expectedResponse.name) || 500;
 
 		if (options.res.statusCode === 200) {
 			options.res.statusCode = status;
@@ -800,6 +798,21 @@ MockController.prototype = extend(MockController.prototype, {
 				this.options.accessControlAllowCredentials(res.req) :
 				this.options.accessControlAllowCredentials
 		);
+	},
+
+	/**
+	 * @method _getHttpStatusFromFileName
+	 * @param {string} fileName
+	 * @returns {number|void} HTTP status code
+	 * @private
+	 */
+	_getHttpStatusFromFileName: function (fileName) {
+		var reg = (/([\w]+)(-)([0-9]{3})/).exec(fileName);
+
+		if (reg === null) {
+			return;
+		}
+		return parseInt(reg[3], 10);
 	},
 
 });


### PR DESCRIPTION
This PR adds the option to specify a HTTP status code to success responses as well if so desired. It will check if the file name ends in 3 digits, and if so use those so both `success-201.json` and `success-example-201.json` will be valid.

Not sure if this is needed for `_sendSuccessNotJSON` and `_sendSuccessJSON` `options.res.send(responseFile);` case.