### PR TITLE
[fix] Fix mutation of global headers by using Object.assign

### DIFF
--- a/lib/controller/MockController.js
+++ b/lib/controller/MockController.js
@@ -174,7 +174,7 @@ MockController.prototype = extend(MockController.prototype, {
 
 		var path = this._getPath(req.originalUrl, this.options.urlPath, this.options.restPath);
 		var responseHeaders;
-		var headers = this.options.headers || {};
+		var headers = Object.assign({}, this.options.headers);
 		var options;
 
 		if (path.search('favicon.ico') >= 0) {


### PR DESCRIPTION
Hi @smollweide,

sorry, but it's me again. So my colleagues had some fun with another interesting and very subtle bug today. After they added a custom header to the response one of our mocked paths they noticed that this custom headers is now suddenly appearing on all other responses as well. After some digging around they found the issue:
In line 177 of the `_handleMockRequest` method of `MockController.js` there is the following expression:
```
		var headers = this.options.headers || {};
```
So far not a problem. But in line 211 of the very same method there is the following expression:
```
		this._writeDefaultHeader(res, extend(headers, responseHeaders));
```
Since `headers` is only a reference to `this.options.headers` the custom response headers for this particular response are actually copied to the global headers object (via the `extend` call).

Our solution was to clone the global headers object via
```
		var headers = Object.assign({}, this.options.headers);
```

Best regards,
Christian