### PR TITLE
make booleans work for swagger import

### DIFF
--- a/lib/DTOToResponseFuncConverter.js
+++ b/lib/DTOToResponseFuncConverter.js
@@ -184,6 +184,10 @@ DTOToResponseFuncConverter.prototype = extend(DTOToResponseFuncConverter.prototy
 			return this._mapString(key);
 		}
 
+		if (value === 'boolean') {
+			return this._mapBoolean();
+		}
+
 		return value;
 	},
 
@@ -288,6 +292,15 @@ DTOToResponseFuncConverter.prototype = extend(DTOToResponseFuncConverter.prototy
 	 */
 	_mapNumber: function () {
 		return this._getFaker('random.number', '');
+	},
+
+	/**
+	 * @method _mapBoolean
+	 * @returns {Boolean}
+	 * @private
+	 */
+	_mapBoolean: function () {
+		return this._getFaker('random.boolean', '');
 	},
 
 	/**


### PR DESCRIPTION
Hi,

I just stumbled over the issue that booleans in my Swagger-API were converted to **"boolean"** in the DTO to response function which end's up being the wrong type (String instead of Boolean).

I'm completely new to the project but I tried to involve faker for that as done for the strings.

Thanks
Johannes