### PR TITLE
Bugfix/remove dublicated json suffix

### DIFF
--- a/lib/ValidatorResponse.js
+++ b/lib/ValidatorResponse.js
@@ -69,7 +69,7 @@ ValidatorResponse.prototype = extend(ValidatorResponse.prototype, {
 		if (this._isValid) {
 			this._pathMethod = this._path + '/' + this._method;
 			this._pathSchema = this._pathMethod + '/response_schema.json';
-			this._pathMockData = this._pathMethod + '/mock/' + this._expected + '.json';
+			this._pathMockData = this._pathMethod + '/mock/' + this._expected;
 			this._dataSchema = {};
 			this._dataExpected = {};
 			this._readFiles();


### PR DESCRIPTION
If you validate a response the file suffix ".json" appears twice like "success.json.json". This code change fixes the issue.