### PR TITLE
Added headers to ejs context

### DIFF
--- a/lib/controller/MockController.js
+++ b/lib/controller/MockController.js
@@ -284,6 +284,7 @@ MockController.prototype = extend(MockController.prototype, {
 				faker: faker,
 				params: this._getDynamicPathParams(options),
 				query: options.req.query,
+				headers: options.req.headers,
 				__dirname: this.options.dirName,
 			};
 


### PR DESCRIPTION
One of my projects requires to inspect headers and slightly return different mocks depending on a certain header. This PR adds headers to the EJS context. Would be cool to merge and release.