### PR TITLE
Fix issue with trailing new line in response.txt file

### DIFF
--- a/lib/controller/MockController.js
+++ b/lib/controller/MockController.js
@@ -597,7 +597,7 @@ MockController.prototype = extend(MockController.prototype, {
 		}
 
 		return {
-			name: name,
+			name: name.trim(),
 			type: type,
 		};
 	},


### PR DESCRIPTION
Some projects are set up with a trailing new line at the end of a file this could be due to editorconfig setting insert_final_newline=true OR within the editor itself.

This means the response.txt file updates on request when for example it sees ```middleware\n``` to ```success``` and will now ignore the middleware.