### PR TITLE
[add] optional "useTrailingSlashes" option

### DIFF
--- a/doc/readme-options.md
+++ b/doc/readme-options.md
@@ -248,3 +248,10 @@ Optional
 
 A string that defines and enables the options fallback.
 This allows you to define a fallback for every options call except there is one defined for the affected endpoint.
+
+
+#### options.useTrailingSlashes
+Type: `Boolean`
+Optional
+
+A boolean to decide to use trailing slashes in URL if your endpoints always ending with it.

--- a/lib/controller/AppController.js
+++ b/lib/controller/AppController.js
@@ -42,6 +42,7 @@ AppController.prototype = extend(AppController.prototype, {
 	 * @param {string} options.privateKey
 	 * @param {string} options.certificate
 	 * @param {boolean} options.open
+	 * @param {boolean} options.useTrailingSlashes
 	 * @param {string|undefined} options.jsVersion
 	 * @public
 	 */

--- a/lib/controller/MockController.js
+++ b/lib/controller/MockController.js
@@ -392,7 +392,7 @@ MockController.prototype = extend(MockController.prototype, {
 	/**
 	 * @method _processOptionsFallback
 	 * @param {Object} req is the original request
-	 * @param {String} directory for the response
+	 * @param {String} dir directory for the response
 	 * @param {Object} options
 	 * @returns {String}
 	 * @private
@@ -737,7 +737,7 @@ MockController.prototype = extend(MockController.prototype, {
 		path = path.split('?')[0];
 
 		// removing trailing slashes to make it work on windows
-		if (path.slice(-1) === '/') {
+		if (!options.useTrailingSlashes && path.slice(-1) === '/') {
 			path = path.slice(0, -1);
 		}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "node-mock-server",
-    "version": "0.23.8",
+    "version": "0.24.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {


### PR DESCRIPTION
Hello!

We have API endpoints that always ends with trailing slashes, like `/api/v1/products/{id}/`.
So if I generating mocks from our swagger.json I get folders like `/rest/products/#{id}#/GET`
This feature related with https://github.com/smollweide/node-mock-server/pull/75.

Here I've added optional boolean in options to use this feature: `useTrailingSlashes`

Please review it. Thank you!